### PR TITLE
Added sunos to supported platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 , "main" : "index.js"
 , "dependencies" :
   { "coffee-script" : ">=1.2.0"
-  , "sysmo" : "git+ssh://git@github.com:matthiasg/Sysmo.js.git"
+  , "sysmo" : ">=0.0.11"
   }
 , "engines" : { "node" : ">=0.1.97" }
 , "licenses" : []


### PR DESCRIPTION
I think platforms should always be left empty unless the module has dependencies forcing it to support only specific platforms. In our case we deploy on SmartOS.
