### PR TITLE
Add forceArray config option

### DIFF
--- a/lib/ObjectTemplate.coffee
+++ b/lib/ObjectTemplate.coffee
@@ -37,7 +37,9 @@ class ObjectTemplate
     context
   
   processMap: (node) =>
-    
+
+    if @config.forceArray then return @processArray [node]
+
     context = @createMapStructure node
     
     if @config.nestTemplate and (nested_key = @chooseKey(node))

--- a/lib/TemplateConfig.coffee
+++ b/lib/TemplateConfig.coffee
@@ -23,6 +23,7 @@ class TemplateConfig
     @directMap      = !!(@arrayToMap and config.value)
     @nestTemplate   = !!config.nested
     @includeAll     = !!config.all
+    @forceArray     = !!config.forceArray
     
     @config         = config
   


### PR DESCRIPTION
Add `forceArray` config option that, when set to `true`, will wrap the node in an array if it is a map.  Useful when transforming JSON that was converted from XML, in which case a node that may normally contain multiple items will be converted to a JSON map if it only contains a single item.

For example, an XML to JSON converter will typically convert the XML:

```xml
<breakfast_menu>
  <food>
    <name>Belgian Waffles</name>
    <price>$5.95</price>
  </food>
</breakfast_menu>
```

to the JSON:

```json
{
  "breakfast_menu": {
    "food": {
      "name": "Belgian Waffles",
      "price": "$5.95"
    }
  }
}
```

The `forceArray` config option can be used to rectify this:

```js
new json2json.ObjectTemplate({
  path: 'breakfast_menu.food',
  all: true,
  forceArray: true
}).transform(json)
```

```[ { name: 'Belgian Waffles', price: '$5.95' } ]```
