### PR TITLE
Allow 'format' function to return an array to make a flat structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The "choose" property defines an array of properties on the original JSON object
               choose: ['SmallImage', 'MediumImage', 'LargeImage'] 
 
 The "format" property defines a function that processes each of the values retrieved from the original JSON object 
-and returns an object with "key" and "value" properties. 
+and returns an object with "key" and "value" properties or an array which contains object(s) with "key" and "value" properties. If an array is returned, all entries in the array are added to the current context node in the new JSON. 
 This allows you to format the key and value however you wish. 
 (If a "key" or "value" property is not returned, the original value is used.) 
 The "node" parameter to the format function is the object or array in the original JSON that is being transformed. 

--- a/lib/ObjectTemplate.coffee
+++ b/lib/ObjectTemplate.coffee
@@ -109,7 +109,10 @@ class ObjectTemplate
   updateContext: (context, node, value, key) =>
     # format key and value
     formatted = @config.applyFormatting node, value, key
-    @aggregateValue context, formatted.key, formatted.value
+    if sysmo.isArray(formatted)
+      @aggregateValue context, item.key, item.value for item in formatted
+    else if formatted?
+      @aggregateValue context, formatted.key, formatted.value
       
   aggregateValue: (context, key, value) =>
     return context unless value?


### PR DESCRIPTION
Hi,

I would like to convert an entry in a map to several entries directly under the same map. This can be easily achieved by allowing the 'format' function to return an array.

For example:
for converting
```javascript
{
    familyName: {
        firstName1: 15,
        firstName2: 21,
        firstName3: 36
    }
}
```
to
```javascript
{
    familyName-firstName1: 15,
    familyName-firstName2: 21,
    familyName-firstName3: 36
}
```

I can write the config:
```javascript
{
    path: ".",
    choose: ["familyName"],
    format: function(node, value, key) {
        var name, res = [];
        for (name in value) {
            res.push({
                key: key + "-" + name,
                value: value[name]
            });
        }
        return res;
    }
}
```

Hope to receive some feedback from you and my pull request can be merged.

Best regards,
Jiawei