### PR TITLE
Update to coffee-script 1.7+ and require coffee-script/register

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 try {
   module.exports = require('./compiled');
 } catch (err) {
-  require('coffee-script');
+  require('coffee-script/register');
   module.exports = require('./lib/json2json');
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 , "directories" : { "lib" : "./lib/" }
 , "main" : "index.js"
 , "dependencies" :
-  { "coffee-script" : ">=1.2.0"
+  { "coffee-script" : ">=1.7.0"
   , "sysmo" : ">=0.0.11"
   }
 , "engines" : { "node" : ">=0.1.97" }


### PR DESCRIPTION
The `coffee-script` dependency in `package.json` is declared as `>=1.2.0` which can result in the very latest version being installed, but version 1.7.0 introduced breaking changes for this project.

From the CoffeeScript changelog for 1.7.0:

> When requiring CoffeeScript files in Node you must now explicitly register the compiler. This can be done with require 'coffee-script/register' or CoffeeScript.register(). Also for configuration such as Mocha's, use coffee-script/register.