### PR TITLE
Add ensureArray option

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,11 @@ To provide more flexibility, a function can be used to dynamically choose which 
               as: 
                 url: 'URL' 
                 height: 'Height.#' 
-                width: 'Width.#' 
+                width: 'Width.#'
+
+The "ensureArray" property indicates that the matched property should be wrapped in an array if it is not already an array.
+
+              ensureArray: true
 
 And finally, create an instance of the "ObjectTemplate" object, 
 passing the template to the constructor. 

--- a/lib/ObjectTemplate.coffee
+++ b/lib/ObjectTemplate.coffee
@@ -1,4 +1,3 @@
-
 # handle CommonJS/Node.js or browser
 
 sysmo           = require?('sysmo') || window?.Sysmo
@@ -37,7 +36,9 @@ class ObjectTemplate
     context
   
   processMap: (node) =>
-    
+
+    if @config.ensureArray then return @processArray [node]
+
     context = @createMapStructure node
     
     if @config.nestTemplate and (nested_key = @chooseKey(node))

--- a/lib/ObjectTemplate.coffee
+++ b/lib/ObjectTemplate.coffee
@@ -32,6 +32,9 @@ class ObjectTemplate
       key = if @config.arrayToMap then @chooseKey(element) else index
       # don't call @processMap because it can lead to double nesting if @config.nestTemplate is true
       value = @createMapStructure(element)
+      # because we don't call @processMap we have to manually ensure values are arrays
+      if @config.arrayToMap and @config.ensureArray and !context[key]?
+        value = [value]
       @updateContext context, element, value, key
     context
   

--- a/lib/TemplateConfig.coffee
+++ b/lib/TemplateConfig.coffee
@@ -23,7 +23,8 @@ class TemplateConfig
     @directMap      = !!(@arrayToMap and config.value)
     @nestTemplate   = !!config.nested
     @includeAll     = !!config.all
-    
+    @ensureArray    = !!config.ensureArray
+
     @config         = config
   
   getPath: =>

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
 , "os" : [ "linux", "darwin", "freebsd", "win32", "sunos" ]
 , "directories" : { "lib" : "./lib/" }
 , "main" : "index.js"
+, "scripts" : { "test": "mocha --compilers coffee:coffee-script/register" }
 , "dependencies" :
   { "coffee-script" : ">=1.2.0"
   , "sysmo" : ">=0.0.11"
   }
+, "devDependencies": { "chai": "^3.5.0" }
 , "engines" : { "node" : ">=0.1.97" }
 , "licenses" : []
 }

--- a/test/transform.coffee
+++ b/test/transform.coffee
@@ -8,6 +8,10 @@ json =
   breakfastMenuArray: [
     { name: 'Belgian Waffles', price: '$5.95' }
   ]
+  sportsTeams: [
+    { id: 'yankees', name: 'New York Yankees', players: [ 'Alex', 'Starlin' ] }
+    { id: 'cubs', name: 'Chicago Cubs', players: 'Jason' }
+  ]
 
 describe 'ObjectTemplate', ->
 
@@ -22,3 +26,8 @@ describe 'ObjectTemplate', ->
       new json2json.ObjectTemplate { path: 'breakfastMenuArray', ensureArray: true, all: true }
         .transform json
         .should.deep.equal [ { name: 'Belgian Waffles', price: '$5.95' } ]
+
+    it 'should wrap the map values in array when `key` and `value` are set and `ensureArray` is `true`', ->
+      new json2json.ObjectTemplate { path: 'sportsTeams', key: 'id', value: 'players', ensureArray: true }
+        .transform json
+        .cubs.should.deep.equal [ 'Jason' ]

--- a/test/transform.coffee
+++ b/test/transform.coffee
@@ -1,0 +1,24 @@
+require('chai').should()
+json2json = require '../'
+
+json =
+  breakfastMenuMap:
+    name: 'Belgian Waffles',
+    price: '$5.95'
+  breakfastMenuArray: [
+    { name: 'Belgian Waffles', price: '$5.95' }
+  ]
+
+describe 'ObjectTemplate', ->
+
+  describe '#transform()', ->
+
+    it 'should wrap the property in an array if `ensureArray` is `true`', ->
+      new json2json.ObjectTemplate { path: 'breakfastMenuMap', ensureArray: true, all: true }
+        .transform json
+        .should.deep.equal [ { name: 'Belgian Waffles', price: '$5.95' } ]
+
+    it 'should not modify the property if it is already an array even if `ensureArray` is `true`', ->
+      new json2json.ObjectTemplate { path: 'breakfastMenuArray', ensureArray: true, all: true }
+        .transform json
+        .should.deep.equal [ { name: 'Belgian Waffles', price: '$5.95' } ]


### PR DESCRIPTION
Add `ensureArray` config option that, when set to `true`, will wrap the node in an array if it is a map.  Useful when transforming JSON that was converted from XML, in which case a node that may normally contain multiple items will be converted to a JSON map if it only contains a single item.

For example, an XML to JSON converter will typically convert the XML:

```xml
<breakfast_menu>
  <food>
    <name>Belgian Waffles</name>
    <price>$5.95</price>
  </food>
</breakfast_menu>
```

to the JSON:

```json
{
  "breakfast_menu": {
    "food": {
      "name": "Belgian Waffles",
      "price": "$5.95"
    }
  }
}
```

The `ensureArray` config option can be used to rectify this:

```js
new json2json.ObjectTemplate({
  path: 'breakfast_menu.food',
  all: true,
  ensureArray: true
}).transform(json)
```

```[ { name: 'Belgian Waffles', price: '$5.95' } ]```

I also added some basic tests for this option that you can run by installing mocha (`npm install -g mocha`) and running `npm test`. Although I'm not sure if they will run correctly without #16 
