### PR TITLE
Add ignoreEmpty option that excludes null and undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,12 @@ The "all" option only works if "choose" is not defined (see below).
               key: 'ASIN' 
               value: 'Title' 
             images: 
-              path: '.' 
+              path: '.'
+
+Any properties on the matched object that are null or undefined will not be copied to the new JSON object.
+To include these properties set "ignoreEmpty" to false.
+
+          ignoreEmpty: false
 
 The "choose" property defines an array of properties on the original JSON object to transform and skip the rest. 
 

--- a/lib/ObjectTemplate.coffee
+++ b/lib/ObjectTemplate.coffee
@@ -119,7 +119,7 @@ class ObjectTemplate
       @aggregateValue context, formatted.key, formatted.value
       
   aggregateValue: (context, key, value) =>
-    return context unless value?
+    return context unless value? or !@config.ignoreEmpty
     
     # if context is an array, just add the value
     if sysmo.isArray(context)

--- a/lib/TemplateConfig.coffee
+++ b/lib/TemplateConfig.coffee
@@ -24,6 +24,7 @@ class TemplateConfig
     @nestTemplate   = !!config.nested
     @includeAll     = !!config.all
     @ensureArray    = !!config.ensureArray
+    @ignoreEmpty    = config.ignoreEmpty != false
 
     @config         = config
   

--- a/test/transform.coffee
+++ b/test/transform.coffee
@@ -12,6 +12,11 @@ json =
     { id: 'yankees', name: 'New York Yankees', players: [ 'Alex', 'Starlin' ] }
     { id: 'cubs', name: 'Chicago Cubs', players: 'Jason' }
   ]
+  user:
+    name: 'Bob',
+    title: '',
+    age: undefined,
+    email: null
 
 describe 'ObjectTemplate', ->
 
@@ -31,3 +36,14 @@ describe 'ObjectTemplate', ->
       new json2json.ObjectTemplate { path: 'sportsTeams', key: 'id', value: 'players', ensureArray: true }
         .transform json
         .cubs.should.deep.equal [ 'Jason' ]
+
+    it 'does not include properties with a `null` or `undefined` value by default', ->
+      new json2json.ObjectTemplate { path: 'user', all: true }
+        .transform json
+        .should.include.keys [ 'name', 'title' ]
+        .should.not.include.keys [ 'age', 'email' ]
+
+    it 'includes properties with a `null` or `undefined` value if `ignoreEmpty` is `false`', ->
+      new json2json.ObjectTemplate { path: 'user', all: true, ignoreEmpty: false }
+        .transform json
+      .should.include.keys [ 'age', 'email' ]


### PR DESCRIPTION
Resolves #18

It seems to me that `ObjectTemplate#aggregateValue()` is the only place where `null` and `undefined` values are excluded, but I'm not great with CoffeeScript.